### PR TITLE
feat: add option to disable window decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 - Use Shift instead of Alt for Videos/Channels page shortcuts
+- Add option to disable window decorations
 - Fix keyboard input working when modal is open
 - Remove old YouTube Email Notifier migration
 

--- a/bindings.ts
+++ b/bindings.ts
@@ -40,9 +40,9 @@ async addChannel(options: AddChannelOptions) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async setGeneralSettings(apiKey: string, maxConcurrentRequests: number, checkInBackground: boolean, windowDecorations: boolean) : Promise<Result<null, string>> {
+async setGeneralSettings(apiKey: string, maxConcurrentRequests: number, checkInBackground: boolean, noWindowDecorations: boolean) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("set_general_settings", { apiKey, maxConcurrentRequests, checkInBackground, windowDecorations }) };
+    return { status: "ok", data: await TAURI_INVOKE("set_general_settings", { apiKey, maxConcurrentRequests, checkInBackground, noWindowDecorations }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -105,7 +105,7 @@ export type AddChannelOptions = { url: string; from_time: number; refresh_rate_m
 export type After = { publishTimeMs: number; id: string }
 export type Channel = { id: string; name: string; icon: string; uploads_playlist_id: string; from_time: number; refresh_rate_ms: number; tags: string[] }
 export type Options = { show_all: boolean; show_archived: boolean; channel_filter: string; tag: string | null; limit: number }
-export type Settings = { api_key: string; max_concurrent_requests: number; channels: Channel[]; check_in_background: boolean; window_decorations?: boolean }
+export type Settings = { api_key: string; max_concurrent_requests: number; channels: Channel[]; check_in_background: boolean; no_window_decorations?: boolean }
 export type UndoHistory = { entries: ([number, Action])[] }
 export type Video = { id: string; title: string; description: string; publishTimeMs: number; 
 /**

--- a/bindings.ts
+++ b/bindings.ts
@@ -40,9 +40,9 @@ async addChannel(options: AddChannelOptions) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async setGeneralSettings(apiKey: string, maxConcurrentRequests: number, checkInBackground: boolean) : Promise<Result<null, string>> {
+async setGeneralSettings(apiKey: string, maxConcurrentRequests: number, checkInBackground: boolean, windowDecorations: boolean) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("set_general_settings", { apiKey, maxConcurrentRequests, checkInBackground }) };
+    return { status: "ok", data: await TAURI_INVOKE("set_general_settings", { apiKey, maxConcurrentRequests, checkInBackground, windowDecorations }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -105,7 +105,7 @@ export type AddChannelOptions = { url: string; from_time: number; refresh_rate_m
 export type After = { publishTimeMs: number; id: string }
 export type Channel = { id: string; name: string; icon: string; uploads_playlist_id: string; from_time: number; refresh_rate_ms: number; tags: string[] }
 export type Options = { show_all: boolean; show_archived: boolean; channel_filter: string; tag: string | null; limit: number }
-export type Settings = { api_key: string; max_concurrent_requests: number; channels: Channel[]; check_in_background: boolean }
+export type Settings = { api_key: string; max_concurrent_requests: number; channels: Channel[]; check_in_background: boolean; window_decorations?: boolean }
 export type UndoHistory = { entries: ([number, Action])[] }
 export type Video = { id: string; title: string; description: string; publishTimeMs: number; 
 /**

--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -155,6 +155,7 @@ pub mod videos {
 	}
 	#[derive(Deserialize, Debug)]
 	pub struct Thumbnail {
+		#[allow(dead_code)]
 		pub url: String,
 	}
 }

--- a/src-tauri/src/data.rs
+++ b/src-tauri/src/data.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{command, Config, Error, State};
+use tauri::{command, Config, Error, Manager, State};
 use tokio::sync::Mutex;
 use url::Url;
 
@@ -283,15 +283,23 @@ pub async fn add_channel(options: AddChannelOptions, data: DataState<'_>) -> Res
 #[command]
 #[specta::specta]
 pub async fn set_general_settings(
+	app_handle: tauri::AppHandle,
 	api_key: String,
 	max_concurrent_requests: u32,
 	check_in_background: bool,
+	window_decorations: bool,
 	data: DataState<'_>,
 ) -> Result<(), String> {
 	let mut data = data.0.lock().await;
 	data.settings().set_api_key(api_key);
 	data.settings().max_concurrent_requests = max_concurrent_requests;
 	data.settings().check_in_background = check_in_background;
+	data.settings().window_decorations = window_decorations;
+	app_handle
+		.get_webview_window("main")
+		.unwrap()
+		.set_decorations(window_decorations)
+		.unwrap();
 	data.save_settings()?;
 	Ok(())
 }

--- a/src-tauri/src/data.rs
+++ b/src-tauri/src/data.rs
@@ -287,18 +287,18 @@ pub async fn set_general_settings(
 	api_key: String,
 	max_concurrent_requests: u32,
 	check_in_background: bool,
-	window_decorations: bool,
+	no_window_decorations: bool,
 	data: DataState<'_>,
 ) -> Result<(), String> {
 	let mut data = data.0.lock().await;
 	data.settings().set_api_key(api_key);
 	data.settings().max_concurrent_requests = max_concurrent_requests;
 	data.settings().check_in_background = check_in_background;
-	data.settings().window_decorations = window_decorations;
+	data.settings().no_window_decorations = no_window_decorations;
 	app_handle
 		.get_webview_window("main")
 		.unwrap()
-		.set_decorations(window_decorations)
+		.set_decorations(!no_window_decorations)
 		.unwrap();
 	data.save_settings()?;
 	Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,7 +114,7 @@ pub async fn run() {
 				.title("Kadium")
 				.inner_size(900.0, 800.0)
 				.min_inner_size(400.0, 150.0)
-				.decorations(settings.unwrap_ref().window_decorations)
+				.decorations(!settings.unwrap_ref().no_window_decorations)
 				.theme(Some(tauri::Theme::Dark));
 
 			#[cfg(target_os = "macos")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,7 +112,8 @@ pub async fn run() {
 			let win = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
 				.title("Kadium")
 				.inner_size(900.0, 800.0)
-				.min_inner_size(400.0, 150.0);
+				.min_inner_size(400.0, 150.0)
+				.decorations(settings.unwrap_ref().window_decorations);
 
 			#[cfg(target_os = "macos")]
 			let win = win.title_bar_style(tauri::TitleBarStyle::Transparent);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,7 +114,7 @@ pub async fn run() {
 				.title("Kadium")
 				.inner_size(900.0, 800.0)
 				.min_inner_size(400.0, 150.0)
-				.decorations(settings.unwrap_ref().window_decorations);
+				.decorations(settings.unwrap_ref().window_decorations)
 				.theme(Some(tauri::Theme::Dark));
 
 			#[cfg(target_os = "macos")]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -25,6 +25,7 @@ impl Default for VersionedSettings {
 			max_concurrent_requests: 5,
 			channels: Vec::new(),
 			check_in_background: true,
+			window_decorations: true,
 		})
 	}
 }
@@ -85,12 +86,19 @@ pub struct Channel {
 	pub tags: Vec<String>,
 }
 
+fn default_true() -> bool {
+	true
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, Type)]
 pub struct Settings {
 	api_key: String,
 	pub max_concurrent_requests: u32,
 	pub channels: Vec<Channel>,
 	pub check_in_background: bool,
+	#[serde(default = "default_true")]
+	#[specta(optional = false)]
+	pub window_decorations: bool,
 }
 impl Settings {
 	pub fn wrap(self) -> VersionedSettings {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -25,7 +25,7 @@ impl Default for VersionedSettings {
 			max_concurrent_requests: 5,
 			channels: Vec::new(),
 			check_in_background: true,
-			window_decorations: true,
+			no_window_decorations: false,
 		})
 	}
 }
@@ -86,21 +86,17 @@ pub struct Channel {
 	pub tags: Vec<String>,
 }
 
-fn default_true() -> bool {
-	true
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, Type)]
 pub struct Settings {
 	api_key: String,
 	pub max_concurrent_requests: u32,
 	pub channels: Vec<Channel>,
 	pub check_in_background: bool,
-	#[serde(default = "default_true")]
-	#[specta(optional = false)]
-	pub window_decorations: bool,
+	#[serde(default)]
+	pub no_window_decorations: bool,
 }
 impl Settings {
+	#[allow(dead_code)]
 	pub fn wrap(self) -> VersionedSettings {
 		VersionedSettings::V1(self)
 	}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -76,6 +76,6 @@ export function enableSampleData() {
 			return channels
 		})(),
 		check_in_background: true,
-		window_decorations: true,
+		no_window_decorations: true,
 	})
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -76,5 +76,6 @@ export function enableSampleData() {
 			return channels
 		})(),
 		check_in_background: true,
+		window_decorations: true,
 	})
 }

--- a/src/lib/modals/Settings.svelte
+++ b/src/lib/modals/Settings.svelte
@@ -9,7 +9,7 @@
 	export let apiKey: string
 	export let maxConcurrentRequests: number
 	export let checkInBackground: boolean
-	export let windowDecorations: boolean
+	export let noWindowDecorations: boolean
 
 	export let visible = false
 	let keyGuideVisible = false
@@ -19,7 +19,7 @@
 			apiKey,
 			maxConcurrentRequests,
 			checkInBackground,
-			windowDecorations,
+			noWindowDecorations,
 		)
 		await loadSettings()
 		visible = false
@@ -51,9 +51,9 @@
 			</div>
 			<div class="toggle-row">
 				<label for="window-decorations">
-					<p>Window Decorations</p>
+					<p>Disable window decorations</p>
 				</label>
-				<Switch id="window-decorations" bind:checked={windowDecorations} />
+				<Switch id="no-window-decorations" bind:checked={noWindowDecorations} />
 			</div>
 			<div class="buttons">
 				<Button secondary on:click={() => (visible = false)}>Cancel</Button>

--- a/src/lib/modals/Settings.svelte
+++ b/src/lib/modals/Settings.svelte
@@ -9,12 +9,18 @@
 	export let apiKey: string
 	export let maxConcurrentRequests: number
 	export let checkInBackground: boolean
+	export let windowDecorations: boolean
 
 	export let visible = false
 	let keyGuideVisible = false
 
 	async function setGeneralSettings() {
-		await commands.setGeneralSettings(apiKey, maxConcurrentRequests, checkInBackground)
+		await commands.setGeneralSettings(
+			apiKey,
+			maxConcurrentRequests,
+			checkInBackground,
+			windowDecorations,
+		)
 		await loadSettings()
 		visible = false
 	}
@@ -42,6 +48,12 @@
 					<p>Check for new videos automatically</p>
 				</label>
 				<Switch id="check-in-background" bind:checked={checkInBackground} />
+			</div>
+			<div class="toggle-row">
+				<label for="window-decorations">
+					<p>Window Decorations</p>
+				</label>
+				<Switch id="window-decorations" bind:checked={windowDecorations} />
 			</div>
 			<div class="buttons">
 				<Button secondary on:click={() => (visible = false)}>Cancel</Button>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -70,6 +70,7 @@
 		apiKey={$settings.api_key}
 		maxConcurrentRequests={$settings.max_concurrent_requests}
 		checkInBackground={$settings.check_in_background}
+		windowDecorations={$settings.window_decorations ?? true}
 		bind:visible={$settingsOpen}
 	/>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -70,7 +70,7 @@
 		apiKey={$settings.api_key}
 		maxConcurrentRequests={$settings.max_concurrent_requests}
 		checkInBackground={$settings.check_in_background}
-		windowDecorations={$settings.window_decorations ?? true}
+		noWindowDecorations={$settings.no_window_decorations ?? false}
 		bind:visible={$settingsOpen}
 	/>
 


### PR DESCRIPTION
Not sure if this warrants a new settings version. Annoying specta seems to mark it as optional in its type generation despite me adding `#[specta(optional = false)]` - I guess because of the serde default thing