### PR TITLE
fix: de-duplicate test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on:
   push:
     branches:
-      - '*'
+      - master
   pull_request:
   workflow_dispatch:
 
@@ -24,6 +24,10 @@ jobs:
           - platform: 'windows-latest'
             target: ''
             args: ''
+    # If it's already running and you push again, cancel the old runs
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.platform }}-${{ matrix.target }}
+      cancel-in-progress: true
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Only run on push to master, and use concurrency rules so that if it's running and you push again it'll stop the old runs